### PR TITLE
Fix log messages in onError handler

### DIFF
--- a/lib/videojs-hlsjs.js
+++ b/lib/videojs-hlsjs.js
@@ -45,17 +45,17 @@
         switch (data.type) {
           case Hls.ErrorTypes.NETWORK_ERROR:
             // try to recover network error
-            this.log('fatal network error encountered, try to recover');
+            console.warn('fatal network error encountered, try to recover');
             this.hls_.startLoad();
             break;
           case Hls.ErrorTypes.MEDIA_ERROR:
-            this.log('fatal media error encountered, try to recover');
+            console.warn('fatal media error encountered, try to recover');
             this.hls_.recoverMediaError();
             break;
           default:
             // cannot recover
             this.hls_.destroy();
-            this.error(data);
+            console.error(data);
             break;
           }
         }


### PR DESCRIPTION
Fixes "Uncaught TypeError: this.log is not a function" on HLS errors.
